### PR TITLE
Fix Core Editor Label Removal

### DIFF
--- a/src/app/controllers/editors/form-core-editor/form-core-editor.component.ts
+++ b/src/app/controllers/editors/form-core-editor/form-core-editor.component.ts
@@ -243,6 +243,12 @@ export class FormCoreEditorComponent implements OnInit, OnDestroy {
         const index = this.labelFormItems.findIndex(e => e.propertyID === labelFieldName);
         this.labelFormItems.splice(index, 1);
         this.label.removeControl(labelFieldName);
+        this.representationItems.push({
+          label: labelFieldName,
+          command: () => {
+            this.onAddLabelField(<PropertyElement>{ propertyID: labelFieldName, propertyValue: '' });
+          },
+        });
       }
       else {
         control?.setValue('');


### PR DESCRIPTION
**Problema:**
quando aggiungo un campo, e poi lo cancello con X, il campo non scompare dal form.

**Passi per riprodurlo:**
Aggiungi una label qualunque, poi clicca direttamente X. Nota che se modifico il campo e poi cancello manualmente, il campo scompare automaticamente.

**Fix:**
L'handler che gestisce il click del tasto per cancellare il campo si affidava direttamente a un cambio in catena: cambiando il valore del campo a '', ci si aspetta che la pipeline del formcontrol che gestisce i cambiamenti di valore aggiorni opportunamente sia la Presentation layer che il backend.
Tuttavia se non avviene alcun cambio (come nel caso in cui si aggiunga il campo, che e' gia' vuoto), il side effect che aggiorna la presentation non viene eseguito.
Un modo per risolvere il problema e' inserire la logica mancante nell'handler.

**Nota di design:**
Il disegno di questa classe non rispetta i principi SOLID, per cui l'handler del cambio di valori non ha una sola responsabilita' (aggiornare il backend, ad esempio) ma due (aggiornare anche la presentazione). Questo comporta che ogni funzione che si appoggia a questo filosofia abbia necessariamente due responsabilita', raddoppiando le possibilita' di avere bug e il costo di manutenzione. Infatti lo stesso bug va risolto anche in altri punti.

Per risolvere velocemente il problema si puo' rimuovere il comportamento automatico di cancellazione del campo quando la stringa e' vuota e vincolare la cancellazione del campo solo alla pressione di X. Questo va ripetuto in tutti i punti dove bug simili appaiono.
Sarebbe comunque opportuno ripensare il codice per separare presentazione e backend, ed evitare di appoggiarsi a un side effect per ottenere l'aggiornamento dell'interfaccia grafica e del backend.