### PR TITLE
Fattorizzazione dei metodi per spostare una label da menu a form e viceversa

### DIFF
--- a/src/app/controllers/editors/form-core-editor/form-core-editor.component.ts
+++ b/src/app/controllers/editors/form-core-editor/form-core-editor.component.ts
@@ -159,9 +159,8 @@ export class FormCoreEditorComponent implements OnInit, OnDestroy {
 
     for (const label of this.formEntry.label) {
       if (label.propertyID === 'variant') continue; //TODO capire come gestire il caso variant
-      if (label.propertyValue != '')
-        this.movePropertyToForm(label.propertyID, label.propertyValue);
-      else
+      this.movePropertyToForm(label.propertyID, label.propertyValue);
+      if (label.propertyValue == '')
         this.movePropertyToMenu(label.propertyID);
     }
     this.formEntry.morphology.forEach(m => {


### PR DESCRIPTION
Ho visto che il problema del tasto X si ripropone in un codice simile (sense-core). Propongo quindi una piccola rifattorizzazione che estrae i metodi di inserimento e rimozione delle label in e dal form dinamico:

- movePropertyToForm: elimina una proprieta' dal menu e la inserisce nel form
- movePropertyToMenu: elimina una proprieta' dal form e la reinserisce nel menu

Questi due metodi consentono di eliminare duplicazione del codice nei punti in cui e' necessario, ma soprattutto attribuiscono chiaramente le responsabilita' di ciascuno riducendo la possibilita' di errore.

Se questo codice va bene, possiamo applicare la stessa logica anche a sense-core.