### PR TITLE
Workaround: quando metadata note é null, viene convertito nella stringa nulla

### DIFF
--- a/src/app/controllers/editors/lex-entry-metadata-editor/lex-entry-metadata-editor.component.ts
+++ b/src/app/controllers/editors/lex-entry-metadata-editor/lex-entry-metadata-editor.component.ts
@@ -51,9 +51,9 @@ export class LexEntryMetadataEditorComponent implements OnInit, OnDestroy {
       debounceTime(500),
       skip(1),
     ).subscribe(note => {
-      this.updateLexicalEntryField(LEXICAL_ENTRY_RELATIONS.NOTE, note).then(() => {
+      this.updateLexicalEntryField(LEXICAL_ENTRY_RELATIONS.NOTE, note?? '').then(() => {
         if (this.lexicalEntry.note !== note) {
-          this.lexicalEntry = <LexicalEntryCore>{ ...this.lexicalEntry, note: note };
+          this.lexicalEntry = <LexicalEntryCore>{ ...this.lexicalEntry, note };
         }
       });
     });
@@ -84,7 +84,7 @@ export class LexEntryMetadataEditorComponent implements OnInit, OnDestroy {
       if (this.lexicalEntry.completionDate !== '') formControlList.completionDate.setValue(new Date(this.lexicalEntry.completionDate).toLocaleString());
       formControlList.revisor.setValue(this.lexicalEntry.revisor);
       if (this.lexicalEntry.revisionDate !== '') formControlList.revisionDate.setValue(new Date(this.lexicalEntry.revisionDate).toLocaleString());
-      formControlList.note.setValue(this.lexicalEntry.note);
+      formControlList.note.setValue(this.lexicalEntry.note?? '');
       if (+this.lexicalEntry.confidence !== -1) formControlList.confidence.setValue(+this.lexicalEntry.confidence * 100);
     });
   }


### PR DESCRIPTION
Ho fatto un quick fix che consente all'interfaccia grafica di funzionare bene. In sostanza converte null in lettura dal servizio in una stringa vuota, e un null in scrittura verso il servizio di nuovo in una stringa vuota.

Anche se questo fixa il comportamento della UI, credo di aver capito che sarebbe necessario cambiare il tipo di LexEntry.note in string : null anziche string?. Cioe' il servizio accetta il valore null, e lo scrive anche nel db correttamente, ma nella UI il campo note non e' dichiarato nullable, bensi' solo optional (undefined). 

La differenza semantica e' sottile ma c'e' ed e' sufficiente per far si che il valore null venga trasformato in una stringa da javascript (in realta' dovrebbe lanciare una eccezione, ma javascript e' troppo buono e piuttosto ti sbauscia il database con delle stringhe "null"). E, al prossimo passaggio, il valore viene necessariamente renderizzato come 'null' e pure scritto nel db.

Per fixare il comportamento in modo formalmente corretto, per me sarebbe opportuno cambiare LexEntry.note in string | null e rimuovere questo workaround. Ho provato a farlo ma implica modifiche piu' profonde che preferisco non fare al momento.

Se e' accettabile che null == '' dal punto di vista della base dati, allora questo workaround va bene e non ci sono altre modifiche da fare per risolvere il problema.