### PR TITLE
Implementazione metadata per form e sense

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -39,6 +39,8 @@ import { TabsLexicalEntryComponent } from './controllers/tab-controllers/tabs-le
 import { TabsSenseComponent } from './controllers/tab-controllers/tabs-sense/tabs-sense.component';
 import { SharedModule } from './modules/shared.module';
 import { SemanticRelEditorComponent } from './controllers/editors/semantic-rel-editor/semantic-rel-editor.component';
+import { FormMetadataEditorComponent } from './controllers/editors/form-metadata-editor/form-metadata-editor.component';
+import { SenseMetadataEditorComponent } from './controllers/editors/sense-metadata-editor/sense-metadata-editor.component';
 
 @NgModule({
   declarations: [
@@ -63,6 +65,8 @@ import { SemanticRelEditorComponent } from './controllers/editors/semantic-rel-e
     TabsFormComponent,
     TabsSenseComponent,
     LexEntryMetadataEditorComponent,
+    FormMetadataEditorComponent,
+    SenseMetadataEditorComponent,
     LexEntryEditorComponent,
     FormCoreEditorComponent,
     SenseCoreEditorComponent,

--- a/src/app/controllers/editors/form-metadata-editor/form-metadata-editor.component.html
+++ b/src/app/controllers/editors/form-metadata-editor/form-metadata-editor.component.html
@@ -1,0 +1,28 @@
+<!--PLACEHOLDER quando siamo in fase di loading dati-->
+<div class="card" [style]="{'height': '100%', 'overflow-y': 'scroll'}">
+  <form [formGroup]="form" class="formgrid grid">
+    <div class="field col-6">
+      <label for="creator">Creator</label>
+      <input name="creator" formControlName="creator" pInputText type="text"
+        class="text-base text-color surface-overlay p-2 border-1 border-solid surface-border border-round appearance-none outline-none focus:border-primary w-full">
+    </div>
+    <div class="field col-6">
+      <label for="creationDate">Creation date</label>
+      <input name="creationDate" formControlName="creationDate" pInputText type="text"
+        class="text-base text-color surface-overlay p-2 border-1 border-solid surface-border border-round appearance-none outline-none focus:border-primary w-full">
+    </div>
+    <div class="field col-6">
+      <label for="provenance">Provenance</label>
+      <input name="provenance" formControlName="provenance" pInputText type="text"
+        class="text-base text-color surface-overlay p-2 border-1 border-solid surface-border border-round appearance-none outline-none focus:border-primary w-full">
+    </div>
+    <div class="field col-6">
+      <label for="confidence">{{ confidenceLabel }}</label>
+      <p-inputNumber name="confidence" formControlName="confidence" suffix="%" [min]="0" [max]="100" class="w-full" styleClass="w-full"></p-inputNumber>
+    </div>
+    <div class="field col-12">
+      <label for="note">Note</label>
+      <p-editor name="note" formControlName="note"></p-editor>
+    </div>
+  </form>
+</div>

--- a/src/app/controllers/editors/form-metadata-editor/form-metadata-editor.component.scss
+++ b/src/app/controllers/editors/form-metadata-editor/form-metadata-editor.component.scss
@@ -1,0 +1,19 @@
+label {
+  width: 100%;
+}
+
+p-selectButton {
+  float: right;
+}
+
+::ng-deep legend {
+  width: auto;
+  float: inherit;
+  font-size: inherit;
+  font-weight: 600;
+}
+
+.fieldset-small {
+  height: 1.5rem !important;
+  width: 1.5rem;
+}

--- a/src/app/controllers/editors/form-metadata-editor/form-metadata-editor.component.spec.ts
+++ b/src/app/controllers/editors/form-metadata-editor/form-metadata-editor.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FormMetadataEditorComponent } from './form-metadata-editor.component';
+
+describe('FormMetadataEditorComponent', () => {
+  let component: FormMetadataEditorComponent;
+  let fixture: ComponentFixture<FormMetadataEditorComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ FormMetadataEditorComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(FormMetadataEditorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/controllers/editors/form-metadata-editor/form-metadata-editor.component.ts
+++ b/src/app/controllers/editors/form-metadata-editor/form-metadata-editor.component.ts
@@ -1,0 +1,118 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
+import { MessageService } from 'primeng/api';
+import { Observable, Subject, catchError, debounceTime, skip, take, takeUntil, throwError } from 'rxjs';
+import { FormCore } from 'src/app/models/lexicon/lexical-entry.model';
+import { FORM_RELATIONS } from 'src/app/models/lexicon/lexicon-updater';
+import { User } from 'src/app/models/user';
+import { CommonService } from 'src/app/services/common.service';
+import { LexiconService } from 'src/app/services/lexicon.service';
+import { MessageConfigurationService } from 'src/app/services/message-configuration.service';
+import { UserService } from 'src/app/services/user.service';
+
+@Component({
+  selector: 'app-form-metadata-editor',
+  templateUrl: './form-metadata-editor.component.html',
+  styleUrls: ['./form-metadata-editor.component.scss']
+})
+export class FormMetadataEditorComponent implements OnInit, OnDestroy {
+  private readonly unsubscribe$ = new Subject();
+  @Input() entry$!: Observable<FormCore>;
+  @Input() confidenceLabel = 'Confidence';
+  form = new FormGroup({
+    creator: new FormControl<string>({ value: '', disabled: true }),
+    creationDate: new FormControl<string>({ value: '', disabled: true }),
+    provenance: new FormControl<string>(''),
+    confidence: new FormControl<number | undefined>(undefined),
+    note: new FormControl<string>(''),
+  });
+  entry!: FormCore;
+  currentUser!: User;
+
+  constructor(
+    private lexiconService: LexiconService,
+    private userService: UserService,
+    private messageService: MessageService,
+    private msgConfService: MessageConfigurationService,
+    private commonService: CommonService,
+  ) {
+    this.userService.retrieveCurrentUser().pipe(
+      take(1),
+    ).subscribe(cu => {
+      this.currentUser = cu;
+    });
+
+    const formControlList = this.form.controls;
+    this.subscribe(formControlList.note, FORM_RELATIONS.NOTE, 'note');
+    this.subscribe(formControlList.confidence, FORM_RELATIONS.CONFIDENCE, 'confidence');
+
+  }
+
+  private subscribe(control: FormControl, fieldType: any, fieldName:string) {
+    control.valueChanges.pipe(
+      takeUntil(this.unsubscribe$),
+      debounceTime(500),
+      skip(1),
+    ).subscribe(value => {
+      this.updateLexicalFormField(fieldType, fieldName, value?? '').then(() => {
+        this.entry = { ...this.entry, [fieldName]: value?? '' };
+      });
+    });
+  }
+
+  ngOnInit(): void {
+
+    this.entry$.pipe(
+      takeUntil(this.unsubscribe$),
+    ).subscribe(le => {
+      this.entry = le;
+      const formControlList = this.form.controls;
+      formControlList.creator.setValue(this.entry.creator);
+      if (this.entry.creationDate !== '') formControlList.creationDate.setValue(new Date(this.entry.creationDate).toLocaleString());
+      formControlList.note.setValue(this.entry.note?? '');
+      if (+this.entry.confidence !== -1) formControlList.confidence.setValue(+this.entry.confidence * 100);
+    });
+
+  }
+
+  ngOnDestroy(): void {
+    this.unsubscribe$.next(null);
+    this.unsubscribe$.complete();
+  }
+
+  private async manageUpdateObservable(updateObs: Observable<string>, relation: string) {
+    updateObs.pipe(
+      take(1),
+      catchError((error: HttpErrorResponse) => {
+        const msg = this.msgConfService.generateWarningMessageConfig(`Update "${relation}" failed `);
+        this.messageService.add(msg);
+        return throwError(() => new Error(error.error));
+      }),
+    ).subscribe(resp => {
+      this.entry = { ...this.entry, lastUpdate: resp };
+      const msg = this.msgConfService.generateSuccessMessageConfig(`Update "${relation}" success `);
+      this.messageService.add(msg);
+    });
+  }
+
+  private async updateLexicalFormField(relation: FORM_RELATIONS, fieldName: string, value: any) {
+    if (value === this.entry[fieldName as keyof FormCore]) return;
+
+    if (!this.currentUser.name) {
+      this.messageService.add(this.msgConfService.generateWarningMessageConfig(`Current user not found`));
+      return;
+    }
+
+    if (relation === FORM_RELATIONS.CONFIDENCE) {
+      value /= 100;
+    }
+
+    const obs = this.lexiconService.updateLexicalForm(
+      this.currentUser.name,
+      this.entry.form,
+      {relation, value}
+    );
+
+    this.manageUpdateObservable(obs, relation); }
+}

--- a/src/app/controllers/editors/sense-metadata-editor/sense-metadata-editor.component.html
+++ b/src/app/controllers/editors/sense-metadata-editor/sense-metadata-editor.component.html
@@ -1,0 +1,28 @@
+<!--PLACEHOLDER quando siamo in fase di loading dati-->
+<div class="card" [style]="{'height': '100%', 'overflow-y': 'scroll'}">
+  <form [formGroup]="form" class="formgrid grid">
+    <div class="field col-6">
+      <label for="creator">Creator</label>
+      <input name="creator" formControlName="creator" pInputText type="text"
+        class="text-base text-color surface-overlay p-2 border-1 border-solid surface-border border-round appearance-none outline-none focus:border-primary w-full">
+    </div>
+    <div class="field col-6">
+      <label for="creationDate">Creation date</label>
+      <input name="creationDate" formControlName="creationDate" pInputText type="text"
+        class="text-base text-color surface-overlay p-2 border-1 border-solid surface-border border-round appearance-none outline-none focus:border-primary w-full">
+    </div>
+    <div class="field col-6">
+      <label for="provenance">Provenance</label>
+      <input name="provenance" formControlName="provenance" pInputText type="text"
+        class="text-base text-color surface-overlay p-2 border-1 border-solid surface-border border-round appearance-none outline-none focus:border-primary w-full">
+    </div>
+    <div class="field col-6">
+      <label for="confidence">{{ confidenceLabel }}</label>
+      <p-inputNumber name="confidence" formControlName="confidence" suffix="%" [min]="0" [max]="100" class="w-full" styleClass="w-full"></p-inputNumber>
+    </div>
+    <div class="field col-12">
+      <label for="note">Note</label>
+      <p-editor name="note" formControlName="note"></p-editor>
+    </div>
+  </form>
+</div>

--- a/src/app/controllers/editors/sense-metadata-editor/sense-metadata-editor.component.scss
+++ b/src/app/controllers/editors/sense-metadata-editor/sense-metadata-editor.component.scss
@@ -1,0 +1,19 @@
+label {
+  width: 100%;
+}
+
+p-selectButton {
+  float: right;
+}
+
+::ng-deep legend {
+  width: auto;
+  float: inherit;
+  font-size: inherit;
+  font-weight: 600;
+}
+
+.fieldset-small {
+  height: 1.5rem !important;
+  width: 1.5rem;
+}

--- a/src/app/controllers/editors/sense-metadata-editor/sense-metadata-editor.component.spec.ts
+++ b/src/app/controllers/editors/sense-metadata-editor/sense-metadata-editor.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SenseMetadataEditorComponent } from './sense-metadata-editor.component';
+
+describe('SenseMetadataEditorComponent', () => {
+  let component: SenseMetadataEditorComponent;
+  let fixture: ComponentFixture<SenseMetadataEditorComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ SenseMetadataEditorComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(SenseMetadataEditorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/controllers/editors/sense-metadata-editor/sense-metadata-editor.component.ts
+++ b/src/app/controllers/editors/sense-metadata-editor/sense-metadata-editor.component.ts
@@ -1,0 +1,120 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
+import { MessageService } from 'primeng/api';
+import { Observable, Subject, catchError, debounceTime, skip, take, takeUntil, throwError } from 'rxjs';
+import { SenseCore } from 'src/app/models/lexicon/lexical-entry.model';
+import { LEXICAL_SENSE_RELATIONS } from 'src/app/models/lexicon/lexicon-updater';
+import { User } from 'src/app/models/user';
+import { CommonService } from 'src/app/services/common.service';
+import { LexiconService } from 'src/app/services/lexicon.service';
+import { MessageConfigurationService } from 'src/app/services/message-configuration.service';
+import { UserService } from 'src/app/services/user.service';
+
+@Component({
+  selector: 'app-sense-metadata-editor',
+  templateUrl: './sense-metadata-editor.component.html',
+  styleUrls: ['./sense-metadata-editor.component.scss']
+})
+export class SenseMetadataEditorComponent implements OnInit, OnDestroy {
+  private readonly unsubscribe$ = new Subject();
+  @Input() entry$!: Observable<SenseCore>;
+  @Input() confidenceLabel = 'Confidence';
+  form = new FormGroup({
+    creator: new FormControl<string>({ value: '', disabled: true }),
+    creationDate: new FormControl<string>({ value: '', disabled: true }),
+    provenance: new FormControl<string>(''),
+    confidence: new FormControl<number | undefined>(undefined),
+    note: new FormControl<string>(''),
+  });
+  entry!: SenseCore;
+  currentUser!: User;
+
+  constructor(
+    private lexiconService: LexiconService,
+    private userService: UserService,
+    private messageService: MessageService,
+    private msgConfService: MessageConfigurationService,
+    private commonService: CommonService,
+  ) {
+    this.userService.retrieveCurrentUser().pipe(
+      take(1),
+    ).subscribe(cu => {
+      this.currentUser = cu;
+    });
+
+    const formControlList = this.form.controls;
+    this.subscribe(formControlList.note, LEXICAL_SENSE_RELATIONS.NOTE, 'note');
+    this.subscribe(formControlList.confidence, LEXICAL_SENSE_RELATIONS.CONFIDENCE, 'confidence');
+  }
+
+  private subscribe(control: FormControl, fieldType: any, fieldName:string) {
+    control.valueChanges.pipe(
+      takeUntil(this.unsubscribe$),
+      debounceTime(500),
+      skip(1),
+    ).subscribe(value => {
+      this.updateLexicalSenseField(fieldType, fieldName, value?? '').then(() => {
+        this.entry = { ...this.entry, [fieldName]: value?? '' };
+      });
+    });
+  }
+
+  ngOnInit(): void {
+    this.loadData();
+  }
+
+  private loadData(): void {
+    this.entry$.pipe(
+      takeUntil(this.unsubscribe$),
+    ).subscribe(le => {
+      this.entry = le;
+      const formControlList = this.form.controls;
+      formControlList.creator.setValue(this.entry.creator);
+      if (this.entry.creationDate !== '') formControlList.creationDate.setValue(new Date(this.entry.creationDate).toLocaleString());
+      formControlList.note.setValue(this.entry.note?? '');
+      if (+this.entry.confidence !== -1) formControlList.confidence.setValue(+this.entry.confidence * 100);
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.unsubscribe$.next(null);
+    this.unsubscribe$.complete();
+  }
+
+  private async manageUpdateObservable(updateObs: Observable<string>, relation: string) {
+    updateObs.pipe(
+      take(1),
+      catchError((error: HttpErrorResponse) => {
+        const msg = this.msgConfService.generateWarningMessageConfig(`Update "${relation}" failed `);
+        this.messageService.add(msg);
+        return throwError(() => new Error(error.error));
+      }),
+    ).subscribe(resp => {
+      this.entry = { ...this.entry, lastUpdate: resp };
+      const msg = this.msgConfService.generateSuccessMessageConfig(`Update "${relation}" success `);
+      this.messageService.add(msg);
+    });
+  }
+
+  private async updateLexicalSenseField(relation: LEXICAL_SENSE_RELATIONS, fieldName: string, value: any) {
+    if (value === this.entry[fieldName as keyof SenseCore]) return;
+
+    if (!this.currentUser.name) {
+      this.messageService.add(this.msgConfService.generateWarningMessageConfig(`Current user not found`));
+      return;
+    }
+
+    if (relation === LEXICAL_SENSE_RELATIONS.CONFIDENCE) {
+      value /= 100;
+    }
+
+    const obs = this.lexiconService.updateLexicalSense(
+      this.currentUser.name,
+      this.entry.sense,
+      {relation, value}
+    );
+
+    this.manageUpdateObservable(obs, relation);
+  }
+}

--- a/src/app/controllers/tab-controllers/tabs-form/tabs-form.component.html
+++ b/src/app/controllers/tab-controllers/tabs-form/tabs-form.component.html
@@ -4,6 +4,6 @@
     <app-form-core-editor *ngIf="formEntry && selectedTab === 0" [formEntry]="formEntry"></app-form-core-editor>
   </p-tabPanel>
   <p-tabPanel header="Metadata">
-    <p-skeleton *ngIf="!formEntry" width="30rem" height="40rem"></p-skeleton>
+    <app-form-metadata-editor *ngIf="formEntry && selectedTab === 1" [entry$]="entry$" confidenceLabel="Form confidence"></app-form-metadata-editor>
   </p-tabPanel>
 </p-tabView>

--- a/src/app/controllers/tab-controllers/tabs-form/tabs-form.component.ts
+++ b/src/app/controllers/tab-controllers/tabs-form/tabs-form.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnDestroy, OnInit } from '@angular/core';
-import { Subject, take, takeUntil } from 'rxjs';
+import { Observable, Subject, take, takeUntil } from 'rxjs';
 import { FormCore } from 'src/app/models/lexicon/lexical-entry.model';
 import { CommonService } from 'src/app/services/common.service';
 import { LexiconService } from 'src/app/services/lexicon.service';
@@ -20,6 +20,8 @@ export class TabsFormComponent implements OnInit, OnDestroy {
   formEntry: FormCore | undefined;
   /**Tab iniziale selezionato */
   selectedTab = 0;
+  entry$!: Observable<FormCore>;
+
 
   /**
    * Costruttore per TabsFormComponent
@@ -29,7 +31,8 @@ export class TabsFormComponent implements OnInit, OnDestroy {
   constructor(
     private lexiconService: LexiconService,
     private commonService: CommonService,
-  ) { }
+  ) {
+  }
 
   /**Metodo dell'interfaccia OnInit utilizzato per il caricamento iniziale dei dati */
   ngOnInit(): void {
@@ -64,7 +67,9 @@ export class TabsFormComponent implements OnInit, OnDestroy {
    * Metodo che richiama il servizio di recupero della forma
    */
   private loadData() {
-    this.lexiconService.getForm(this.formId).pipe(
+    this.entry$ = this.lexiconService.getForm(this.formId);
+
+    this.entry$.pipe(
       take(1),
     ).subscribe(fe => {
       this.formEntry = fe;

--- a/src/app/controllers/tab-controllers/tabs-sense/tabs-sense.component.html
+++ b/src/app/controllers/tab-controllers/tabs-sense/tabs-sense.component.html
@@ -9,6 +9,6 @@
     <app-semantic-rel-editor *ngIf="senseEntry" [senseEntry]="senseEntry"></app-semantic-rel-editor>
   </p-tabPanel>
   <p-tabPanel header="Metadata">
-    <p-skeleton *ngIf="!senseEntry" width="30rem" height="40rem"></p-skeleton>
+    <app-sense-metadata-editor *ngIf="senseEntry" [entry$]="entry$" confidenceLabel="Sense confidence"></app-sense-metadata-editor>
   </p-tabPanel>
 </p-tabView>

--- a/src/app/controllers/tab-controllers/tabs-sense/tabs-sense.component.ts
+++ b/src/app/controllers/tab-controllers/tabs-sense/tabs-sense.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnDestroy, OnInit } from '@angular/core';
-import { Subject, take, takeUntil } from 'rxjs';
+import { Observable, Subject, take, takeUntil } from 'rxjs';
 import { SenseCore } from 'src/app/models/lexicon/lexical-entry.model';
 import { CommonService } from 'src/app/services/common.service';
 import { LexiconService } from 'src/app/services/lexicon.service';
@@ -18,6 +18,8 @@ export class TabsSenseComponent implements OnInit, OnDestroy {
   @Input() lexEntryId!: string;
   /**Senso in lavorazione */
   senseEntry: SenseCore | undefined;
+
+  entry$!: Observable<SenseCore>;
 
   /**
    * Costruttore per TabsSenseComponent
@@ -62,8 +64,11 @@ export class TabsSenseComponent implements OnInit, OnDestroy {
  * Metodo che richiama il servizio di recupero del senso
  */
   private loadData(): void {
-    this.lexiconService.getSense(this.senseId).pipe(
+    this.entry$ = this.lexiconService.getSense(this.senseId);
+    this.entry$.pipe(
       take(1),
-    ).subscribe(se => { this.senseEntry = se; });
+    ).subscribe(se => {
+      this.senseEntry = se;
+    });
   }
 }


### PR DESCRIPTION
I due nuovi componenti si assomigliano il piu' possibile, per poter preparare una fattorizzazione successiva.

Ho duplicato il lexicalentrymetadata component, e ottimizzato le classi per estrarre i metodi differenti (in particolare: caricamento e salvataggio dati da e verso il servizio).

Infatti fattorizzare le tre classi in una non e' immediato per la struttura dei servizi, che specializza tutti i metodi e i tipi sottostanti. occorre dunque prima separare le funzionalita' di update e caricamento per poter fattorizzare le classi in un passo successivo. 

Nota: il campo Provenance non e' implementato neanche nell'originale