### PR TITLE
Rimosse chiamate a Cash

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -11,12 +11,24 @@ import { AuthConfigModule } from './config/auth.config.module';
 import { PageControllersModule } from './controllers/page-controllers/page-controllers.module';
 
 import { ConfirmationService, MessageService } from 'primeng/api';
-import { AnnotationEditorComponent } from './controllers/editors/annotation-editor/annotation-editor.component';
+import { BaseMetadataEditorComponent } from './controllers/editors/base-metadata-editor/base-metadata-editor.component';
+import { FormCoreEditorComponent } from './controllers/editors/form-core-editor/form-core-editor.component';
+import { FormMetadataEditorComponent } from './controllers/editors/form-metadata-editor/form-metadata-editor.component';
+import { LexEntryEditorComponent } from './controllers/editors/lex-entry-editor/lex-entry-editor.component';
+import { LexEntryMetadataEditorComponent } from './controllers/editors/lex-entry-metadata-editor/lex-entry-metadata-editor.component';
 import { LexicalEntryEditorComponent } from './controllers/editors/lexical-entry-editor/lexical-entry-editor.component';
 import { RelationEditorComponent } from './controllers/editors/relation-editor/relation-editor.component';
+import { SemanticRelEditorComponent } from './controllers/editors/semantic-rel-editor/semantic-rel-editor.component';
+import { SenseCoreEditorComponent } from './controllers/editors/sense-core-editor/sense-core-editor.component';
+import { SenseMetadataEditorComponent } from './controllers/editors/sense-metadata-editor/sense-metadata-editor.component';
+import { TextAnnotationEditorComponent } from './controllers/editors/text-annotation-editor/text-annotation-editor.component';
 import { IconsModule } from './controllers/icons/icons.module';
+import { TabsFormComponent } from './controllers/tab-controllers/tabs-form/tabs-form.component';
+import { TabsLexicalEntryComponent } from './controllers/tab-controllers/tabs-lexical-entry/tabs-lexical-entry.component';
+import { TabsSenseComponent } from './controllers/tab-controllers/tabs-sense/tabs-sense.component';
 import { MainLayoutComponent } from './layouts/main-layout/main-layout.component';
 import { WorkspaceLayoutComponent } from './layouts/workspace-layout/workspace-layout.component';
+import { SharedModule } from './modules/shared.module';
 import { WorkspaceCorpusExplorerComponent } from './pages/workspace/workspace-corpus-explorer/workspace-corpus-explorer.component';
 import { WorkspaceLayersVisibilityManagerComponent } from './pages/workspace/workspace-layers-visibility-manager/workspace-layers-visibility-manager.component';
 import { WorkspaceLexiconEditTileComponent } from './pages/workspace/workspace-lexicon-edit-tile/workspace-lexicon-edit-tile.component';
@@ -28,21 +40,6 @@ import { WorkspaceTextWindowComponent } from './pages/workspace/workspace-text-w
 import { WorkspaceComponent } from './pages/workspace/workspace.component';
 import { PendingChangesGuard } from './pending-changes-guard';
 import { CommonService } from './services/common.service';
-// import { FormEditorComponent } from './controllers/editors/form-editor/form-editor.component';
-import { FormCoreEditorComponent } from './controllers/editors/form-core-editor/form-core-editor.component';
-import { LexEntryEditorComponent } from './controllers/editors/lex-entry-editor/lex-entry-editor.component';
-import { LexEntryMetadataEditorComponent } from './controllers/editors/lex-entry-metadata-editor/lex-entry-metadata-editor.component';
-import { SenseCoreEditorComponent } from './controllers/editors/sense-core-editor/sense-core-editor.component';
-// import { SenseEditorComponent } from './controllers/editors/sense-editor/sense-editor.component';
-import { BaseMetadataEditorComponent } from './controllers/editors/base-metadata-editor/base-metadata-editor.component';
-import { FormMetadataEditorComponent } from './controllers/editors/form-metadata-editor/form-metadata-editor.component';
-import { SemanticRelEditorComponent } from './controllers/editors/semantic-rel-editor/semantic-rel-editor.component';
-import { SenseMetadataEditorComponent } from './controllers/editors/sense-metadata-editor/sense-metadata-editor.component';
-import { TextAnnotationEditorComponent } from './controllers/editors/text-annotation-editor/text-annotation-editor.component';
-import { TabsFormComponent } from './controllers/tab-controllers/tabs-form/tabs-form.component';
-import { TabsLexicalEntryComponent } from './controllers/tab-controllers/tabs-lexical-entry/tabs-lexical-entry.component';
-import { TabsSenseComponent } from './controllers/tab-controllers/tabs-sense/tabs-sense.component';
-import { SharedModule } from './modules/shared.module';
 
 @NgModule({
   declarations: [
@@ -55,14 +52,11 @@ import { SharedModule } from './modules/shared.module';
     WorkspaceCorpusExplorerComponent,
     MainLayoutComponent,
     WorkspaceTextWindowComponent,
-    AnnotationEditorComponent,
     WorkspaceLayersVisibilityManagerComponent,
     RelationEditorComponent,
     WorkspaceLexiconTileComponent,
     WorkspaceLexiconEditTileComponent,
     LexicalEntryEditorComponent,
-    // FormEditorComponent,
-    // SenseEditorComponent,
     TabsLexicalEntryComponent,
     TabsFormComponent,
     TabsSenseComponent,

--- a/src/app/services/annotation.service.ts
+++ b/src/app/services/annotation.service.ts
@@ -1,7 +1,6 @@
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { AnnotationFeature } from 'src/app/models/annotation/annotation-feature';
 import { environment } from 'src/environments/environment';
 import { v4 as uuidv4 } from 'uuid';
 import { PaginatedResponse } from '../models/texto/paginated-response';
@@ -14,18 +13,12 @@ import { TAnnotationFeature } from '../models/texto/t-annotation-feature';
 })
 export class AnnotationService {
 
-  /**Url per le chiamate relative alle annotazioni */
-  private annotationUrl: string;
-  /**Url per le chiamate a cash */
-  private cashUrl: string;
   private textoUrl: string;
   /**
    * Costruttore per AnnotationService
    * @param http {HttpClient} effettua le chiamate HTTP
    */
   constructor(private http: HttpClient) {
-    this.annotationUrl = environment.annotationUrl;
-    this.cashUrl = environment.cashUrl;
     this.textoUrl = environment.textoUrl;
   }
 
@@ -38,11 +31,11 @@ export class AnnotationService {
    * @param nodeId {number} identificativo numerico del nodo
    * @returns {Observable<any>} observable delle annotazioni
    */
-  public retrieveByNodeId(nodeId: number): Observable<any> {
-    const uuid = uuidv4();
-    //SIM: aggiunto public/ e rimosso v1/ per compatibilità con la nuova api di CASH
-    return this.http.get<any>(`${this.cashUrl}/api/public/annotation?requestUUID=${uuid}&nodeid=${nodeId}`);
-  }
+  // public retrieveByNodeId(nodeId: number): Observable<any> {
+  //   const uuid = uuidv4();
+  //   //SIM: aggiunto public/ e rimosso v1/ per compatibilità con la nuova api di CASH
+  //   return this.http.get<any>(`${this.cashUrl}/api/public/annotation?requestUUID=${uuid}&nodeid=${nodeId}`);
+  // }
 
   /**
    * POST che effettua la creazione di una nuova annotazione
@@ -50,44 +43,44 @@ export class AnnotationService {
    * @param item {any} la nuova annotazione
    * @returns {Observable<any>} observable della nuova annotazione
    */
-  public create(nodeId: number, item: any): Observable<any> {
-    const uuid = uuidv4();
-    //SIM: rimosso v1/ per compatibilità con la nuova api di CASH
-    return this.http.post<any>(`${this.cashUrl}/api/annotation?requestUUID=${uuid}&nodeid=${nodeId}`, item);
-  }
+  // public create(nodeId: number, item: any): Observable<any> {
+  //   const uuid = uuidv4();
+  //   //SIM: rimosso v1/ per compatibilità con la nuova api di CASH
+  //   return this.http.post<any>(`${this.cashUrl}/api/annotation?requestUUID=${uuid}&nodeid=${nodeId}`, item);
+  // }
 
   /**
    * PUT che aggiorna i dati di un'annotazione
    * @param item {any} un'annotazione modificata
    * @returns {Observable<any>} observable dell'annotazione modificata
    */
-  public update(item: any) {
-    const uuid = uuidv4();
-    //SIM: rimosso v1/ per compatibilità con la nuova api di CASH
-    return this.http.put<any>(`${this.cashUrl}/api/annotation?requestUUID=${uuid}`, item);
-  }
+  // public update(item: any) {
+  //   const uuid = uuidv4();
+  //   //SIM: rimosso v1/ per compatibilità con la nuova api di CASH
+  //   return this.http.put<any>(`${this.cashUrl}/api/annotation?requestUUID=${uuid}`, item);
+  // }
 
   /**
    * GET che recupera i token dato l'id di un nodo (testuale?) //TODO verificare sullo swagger di cash
    * @param nodeId {number} identificativo numerico
    * @returns {Observable<any>} observable dell'esito
    */
-  public retrieveTokens(nodeId: number): Observable<any> {
-    const uuid = uuidv4();
+  // public retrieveTokens(nodeId: number): Observable<any> {
+  //   const uuid = uuidv4();
 
-    return this.http.get<any>(`${this.cashUrl}/api/v1/token?requestUUID=${uuid}&nodeid=${nodeId}`);
-  }
+  //   return this.http.get<any>(`${this.cashUrl}/api/v1/token?requestUUID=${uuid}&nodeid=${nodeId}`);
+  // }
 
   /**
    * GET che recupera un testo sulla base dell'id
    * @param nodeId {identificativo numerico del nodo testo}
    * @returns {Observable<any>} observable del testo
    */
-  public _retrieveText(nodeId: number): Observable<any> {
-    const uuid = uuidv4();
-    //SIM: aggiunto public/ e rimosso v1/ per compatibilità con la nuova api di CASH
-    return this.http.get<any>(`${this.cashUrl}/api/public/gettext?requestUUID=${uuid}&nodeid=${nodeId}`);
-  }
+  // public _retrieveText(nodeId: number): Observable<any> {
+  //   const uuid = uuidv4();
+  //   //SIM: aggiunto public/ e rimosso v1/ per compatibilità con la nuova api di CASH
+  //   return this.http.get<any>(`${this.cashUrl}/api/public/gettext?requestUUID=${uuid}&nodeid=${nodeId}`);
+  // }
 
   public retrieveText(textId: number, slice: { start: number, end: number | null }): Observable<string> {
     const uuid = uuidv4();
@@ -129,23 +122,23 @@ export class AnnotationService {
    * @param nodeId {number} identificativo numerico
    * @returns {Observable<any>} observable dell'esito
    */
-  public retreiveContent(nodeId: number) {
-    const uuid = uuidv4();
+  // public retreiveContent(nodeId: number) {
+  //   const uuid = uuidv4();
 
-    return this.http.get<any>(`${this.cashUrl}/api/v1/getcontent?requestUUID=${uuid}&nodeid=${nodeId}`);
-  }
+  //   return this.http.get<any>(`${this.cashUrl}/api/v1/getcontent?requestUUID=${uuid}&nodeid=${nodeId}`);
+  // }
 
   /**
    * DELETE che esegue la cancellazione di una annotazione sulla base del suo ID
    * @param annotationId {number} identificativo numerico dell'annotazione
    * @returns {Observable<any>} observable dell'esito
    */
-  public delete(annotationId: number): Observable<any> {
-    const uuid = uuidv4();
+  // public delete(annotationId: number): Observable<any> {
+  //   const uuid = uuidv4();
 
-    //SIM: rimosso v1/ per compatibilità con la nuova api di CASH
-    return this.http.delete<any>(`${this.cashUrl}/api/annotate?requestUUID=${uuid}&annotationID=${annotationId}`);
-  }
+  //   //SIM: rimosso v1/ per compatibilità con la nuova api di CASH
+  //   return this.http.delete<any>(`${this.cashUrl}/api/annotate?requestUUID=${uuid}&annotationID=${annotationId}`);
+  // }
 
   // FINE CHIAMATE CASH SERVER
 
@@ -156,9 +149,9 @@ export class AnnotationService {
    * @param annFeature {AnnotationFeature} feature dell'annotazione
    * @returns {Observable<any>} observable della nuova feature dell'annotazione
    */
-  public _createAnnotationFeature(annFeature: AnnotationFeature): Observable<any> {
-    return this.http.post<any>(`${this.annotationUrl}`, annFeature);
-  }
+  // public _createAnnotationFeature(annFeature: AnnotationFeature): Observable<any> {
+  //   return this.http.post<any>(`${this.annotationUrl}`, annFeature);
+  // }
 
   //non necessario al momento
   /*   public updateAnnotationFeature(annFeatures: AnnotationFeature): Observable<AnnotationFeature> {
@@ -170,9 +163,9 @@ export class AnnotationService {
    * @param id {number} identificativo numerico dell'annotazione
    * @returns {Observable<boolean>} observable dell'esito della cancellazione
    */
-  public deleteAnnotationFeature(id: number): Observable<boolean> {
-    return this.http.delete<boolean>(`${this.annotationUrl}/${id}`);
-  }
+  // public deleteAnnotationFeature(id: number): Observable<boolean> {
+  //   return this.http.delete<boolean>(`${this.annotationUrl}/${id}`);
+  // }
 
   //#region TEXTO BACK END
 

--- a/src/app/services/workspace.service.ts
+++ b/src/app/services/workspace.service.ts
@@ -3,8 +3,7 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { environment } from 'src/environments/environment';
 import { v4 as uuidv4 } from 'uuid';
-import { DocumentSystem } from '../models/corpus/document-system';
-import { ElementType, _ElementType } from '../models/corpus/element-type';
+import { ElementType } from '../models/corpus/element-type';
 import { CorpusElement, FolderElement, ResourceElement } from '../models/texto/corpus-element';
 import { TextChoice } from '../models/tile/text-choice-element.model';
 import { TextTileContent } from '../models/tile/text-tile-content.model';
@@ -12,8 +11,6 @@ import { Tile } from '../models/tile/tile.model';
 import { TextoUser } from '../models/user';
 import { WorkspaceChoice } from '../models/workspace-choice.model';
 import { Workspace } from '../models/workspace.model';
-
-const headers = new HttpHeaders().set('Content-Type', 'application/json'); //TODO verificare rimozione per mancato uso
 
 /**Classe dei servizi per i workspace */
 @Injectable({
@@ -24,8 +21,6 @@ export class WorkspaceService {
 
   /**Url per chiamate relative ai workspace */
   private workspacesUrl: string;
-  /**Url per le chiamate a cash */
-  private cashUrl: string;
   private textoUrl: string;
   private textoDebugUrl: string;
 
@@ -35,7 +30,6 @@ export class WorkspaceService {
    */
   constructor(private http: HttpClient) {
     this.workspacesUrl = environment.workspacesUrl; //inizializzo i due url dall'environment
-    this.cashUrl = environment.cashUrl;
     this.textoUrl = environment.textoUrl;
     this.textoDebugUrl = environment.textoDebugUrl;
   }
@@ -165,12 +159,12 @@ export class WorkspaceService {
    * GET che recupera il sistema documentale
    * @returns {Observable<DocumentSystem>} observable del sistema documentale
    */
-  public _retrieveCorpus(): Observable<DocumentSystem> {
-    const uuid = uuidv4();
-    //SIM: aggiunto public/ nel path
-    return this.http.get<DocumentSystem>(`${this.cashUrl}/api/public/getDocumentSystem?requestUUID=${uuid}`);
-    //return this.http.get<DocumentSystem>('assets/mock/files.json')
-  }
+  // public _retrieveCorpus(): Observable<DocumentSystem> {
+  //   const uuid = uuidv4();
+  //   //SIM: aggiunto public/ nel path
+  //   return this.http.get<DocumentSystem>(`${this.cashUrl}/api/public/getDocumentSystem?requestUUID=${uuid}`);
+  //   //return this.http.get<DocumentSystem>('assets/mock/files.json')
+  // }
 
   public retrieveCorpus(userId?: number): Observable<CorpusElement[]> {
     const uuid = uuidv4();
@@ -190,13 +184,13 @@ export class WorkspaceService {
    * @param file {File} il file da caricare
    * @returns {Observable<any>} observable del file caricato nel sistema documentale
    */
-  public _uploadFile(element_id: number, file: File): Observable<any> {
-    const uuid = uuidv4();
+  // public _uploadFile(element_id: number, file: File): Observable<any> {
+  //   const uuid = uuidv4();
 
-    const formData: FormData = new FormData();
-    formData.append('file', file);
-    return this.http.post<any>(`${this.cashUrl}/api/crud/uploadFile?requestUUID=${uuid}&element-id=${element_id}`, formData);
-  }
+  //   const formData: FormData = new FormData();
+  //   formData.append('file', file);
+  //   return this.http.post<any>(`${this.cashUrl}/api/crud/uploadFile?requestUUID=${uuid}&element-id=${element_id}`, formData);
+  // }
 
   public uploadFile(resourceId: number, file: File) {
     const uuid = uuidv4();
@@ -218,24 +212,24 @@ export class WorkspaceService {
    * @param type {_ElementType} tipo di elemento documentale (file o folder)
    * @returns {Observable<any>} observable dell'elemento documentale aggiornato
    */
-  public _renameElement(element_id: number, rename_string: string, type: _ElementType): Observable<any> {
-    const uuid = uuidv4();
+  // public _renameElement(element_id: number, rename_string: string, type: _ElementType): Observable<any> {
+  //   const uuid = uuidv4();
 
-    const payload = {
-      "uuid": uuid,
-      "user-id": 0,
-      "element-id": element_id,
-      "rename-string": rename_string
-    }
+  //   const payload = {
+  //     "uuid": uuid,
+  //     "user-id": 0,
+  //     "element-id": element_id,
+  //     "rename-string": rename_string
+  //   }
 
-    let operationUrl = "renameFolder";
+  //   let operationUrl = "renameFolder";
 
-    if (type == _ElementType.File) {
-      operationUrl = "renameFile";
-    }
+  //   if (type == _ElementType.File) {
+  //     operationUrl = "renameFile";
+  //   }
 
-    return this.http.post<any>(`${this.cashUrl}/api/crud/${operationUrl}`, payload);
-  }
+  //   return this.http.post<any>(`${this.cashUrl}/api/crud/${operationUrl}`, payload);
+  // }
 
   public renameElement(elementType: string, elementId: number, newName: string) {
     const uuid = uuidv4();
@@ -258,23 +252,23 @@ export class WorkspaceService {
    * @param type {_ElementType} tipo di elemento da eliminare
    * @returns {Observable<any>} observable dell'esito della cancellazione
    */
-  public _removeElement(element_id: number, type: _ElementType): Observable<any> {
-    const uuid = uuidv4();
+  // public _removeElement(element_id: number, type: _ElementType): Observable<any> {
+  //   const uuid = uuidv4();
 
-    const payload = {
-      "uuid": uuid,
-      "user-id": 0,
-      "element-id": element_id
-    }
+  //   const payload = {
+  //     "uuid": uuid,
+  //     "user-id": 0,
+  //     "element-id": element_id
+  //   }
 
-    let operationUrl = "removeFolder";
+  //   let operationUrl = "removeFolder";
 
-    if (type == _ElementType.File) {
-      operationUrl = "removeFile";
-    }
+  //   if (type == _ElementType.File) {
+  //     operationUrl = "removeFile";
+  //   }
 
-    return this.http.post<any>(`${this.cashUrl}/api/crud/${operationUrl}`, payload);
-  }
+  //   return this.http.post<any>(`${this.cashUrl}/api/crud/${operationUrl}`, payload);
+  // }
 
   public removeElement(elementType: string, elementId: number) {
     const uuid = uuidv4();
@@ -294,30 +288,30 @@ export class WorkspaceService {
    * @param type {_ElementType} tipo di elemento documentale
    * @returns {Observable<any>} observable dell'elemento documentale modificato
    */
-  public _moveElement(element_id: number, target_id: number, type: _ElementType): Observable<any> {
-    const uuid = uuidv4();
+  // public _moveElement(element_id: number, target_id: number, type: _ElementType): Observable<any> {
+  //   const uuid = uuidv4();
 
-    let realTargetId = target_id;
-    // To be able to move to the root it is necessary to change the target id from 0 to 1 (which in the db appears to be the root)
-    if (realTargetId == 0) {
-      realTargetId = 1;
-    }
+  //   let realTargetId = target_id;
+  //   // To be able to move to the root it is necessary to change the target id from 0 to 1 (which in the db appears to be the root)
+  //   if (realTargetId == 0) {
+  //     realTargetId = 1;
+  //   }
 
-    const payload = {
-      "uuid": uuid,
-      "user-id": 0,
-      "element-id": element_id,
-      "target-id": realTargetId
-    }
+  //   const payload = {
+  //     "uuid": uuid,
+  //     "user-id": 0,
+  //     "element-id": element_id,
+  //     "target-id": realTargetId
+  //   }
 
-    let operationUrl = "moveFolder";
+  //   let operationUrl = "moveFolder";
 
-    if (type == _ElementType.File) {
-      operationUrl = "moveFileTo";
-    }
+  //   if (type == _ElementType.File) {
+  //     operationUrl = "moveFileTo";
+  //   }
 
-    return this.http.post<any>(`${this.cashUrl}/api/crud/${operationUrl}`, payload);
-  }
+  //   return this.http.post<any>(`${this.cashUrl}/api/crud/${operationUrl}`, payload);
+  // }
 
   public moveElement(elementType: string, elementId: number, targetId: number) { //TODO sostituire elementType con una enum?
     const uuid = uuidv4();
@@ -341,17 +335,17 @@ export class WorkspaceService {
    * @param element_id {number} identificativo numerico dell'elemento
    * @returns {Observable<any>} observable della nuova cartella inserita
    */
-  public _addFolder(element_id: number): Observable<any> {
-    const uuid = uuidv4();
+  // public _addFolder(element_id: number): Observable<any> {
+  //   const uuid = uuidv4();
 
-    const payload = {
-      "uuid": uuid,
-      "user-id": 0,
-      "element-id": element_id
-    }
+  //   const payload = {
+  //     "uuid": uuid,
+  //     "user-id": 0,
+  //     "element-id": element_id
+  //   }
 
-    return this.http.post<any>(`${this.cashUrl}/api/crud/addFolder`, payload);
-  }
+  //   return this.http.post<any>(`${this.cashUrl}/api/crud/addFolder`, payload);
+  // }
 
   public addElement(elementType: ElementType, parentFolderId: number, elementName: string, userId: number): Observable<CorpusElement> {
     const uuid = uuidv4();

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -9,7 +9,7 @@ const appName = "/maia-fe"
 // const issuer = "http://localhost:8080/realms/princnr";
 const issuer = "https://klab.ilc.cnr.it/keycloak/realms/princnr"; //TODO sostituire con keycloak
 // const allowedUrls = 'http://localhost:9000/projectx/api';
-const allowedUrls   = 'https://klab.ilc.cnr.it/projectx/api'; //TODO sostituire con il backend xeel
+const allowedUrls = 'https://klab.ilc.cnr.it/projectx/api'; //TODO sostituire con il backend xeel
 
 export const environment = {
   production: false,
@@ -43,7 +43,6 @@ export const environment = {
   annotationUrl: allowedUrls + '/annotations',
   relationUrl: allowedUrls + '/relations',
   lexoUrl: "/LexO-backend-maia/service/",
-  // cashUrl: "http://localhost:8085",
   cashUrl: "https://klab.ilc.cnr.it/cash-0.0.1-SNAPSHOT",
   textoUrl: "https://146.48.93.234:9443",
   textoDebugUrl: "https://macalbanesi:9443",


### PR DESCRIPTION
Rimosso import di AnnotationEditorComponent (versione precedente non più in uso) e commentati tutti i metodi di chiamata a Cash. Rimosse le chiamate relative alle annotazioni (passate su Texto) e alle relazioni (non ancora implementate su Texto, ma programmate) in workspace-text-window.component.ts