### PR TITLE
Fix language in upload lessico da connl

### DIFF
--- a/src/app/pages/workspace/workspace-lexicon-tile/workspace-lexicon-tile.component.ts
+++ b/src/app/pages/workspace/workspace-lexicon-tile/workspace-lexicon-tile.component.ts
@@ -564,7 +564,7 @@ export class WorkspaceLexiconTileComponent implements OnInit {
     const fileData = new FormData();
     fileData.append('file', this._selectedFile);
 
-    this.lexiconService.uploadConll(lexUpForm['prefix'], lexUpForm['baseIRI'], lexUpForm['author'], lexUpForm['language'], lexUpForm['drop'], fileData).pipe(
+    this.lexiconService.uploadConll(lexUpForm['prefix'], lexUpForm['baseIRI'], lexUpForm['author'], lexUpForm['language'].value, lexUpForm['drop'], fileData).pipe(
       take(1),
       catchError((error: HttpErrorResponse) => {
         this.messageService.add(this.msgConfService.generateWarningMessageConfig(error.error))


### PR DESCRIPTION
La funzionalità di upload di un lessico connl era bloccata da un errore nel passaggio del parametro language, qui risolto.
Noto però un problema (credo di back-end) che causa la duplicazione degli elementi a seguito di upload non in overwrite. Non ho proceduto all'overwrite perché i dati inseriti da Flavia sono ancora necessari.
<img width="749" alt="image" src="https://github.com/MPapini91/maia-fe/assets/61142119/6b713ffd-4c14-41f2-ac23-9cb599e3cd17">
<img width="239" alt="image" src="https://github.com/MPapini91/maia-fe/assets/61142119/2ee458c0-e006-4b36-8d02-eda4bba3e368">
