### PR TITLE
Autosave text fields in Lexicon

### DIFF
--- a/src/app/controllers/editors/base-metadata-editor/base-metadata-editor.component.ts
+++ b/src/app/controllers/editors/base-metadata-editor/base-metadata-editor.component.ts
@@ -1,11 +1,11 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
+import { MessageService } from 'primeng/api';
 import { Observable, Subject, catchError, debounceTime, skip, take, takeUntil, throwError } from 'rxjs';
+import { User } from 'src/app/models/user';
 import { MessageConfigurationService } from 'src/app/services/message-configuration.service';
 import { UserService } from 'src/app/services/user.service';
-import { MessageService } from 'primeng/api';
-import { User } from 'src/app/models/user';
 
 @Component({
   selector: 'app-base-metadata-editor',
@@ -17,7 +17,7 @@ export class BaseMetadataEditorComponent implements OnInit, OnDestroy {
   @Input() entry$!: Observable<any>;
   @Input() confidenceLabel = 'Confidence';
 
-  formControls : {[name: string] : FormControl} = {
+  formControls: { [name: string]: FormControl } = {
     creator: new FormControl<string>({ value: '', disabled: true }),
     creationDate: new FormControl<string>({ value: '', disabled: true }),
     provenance: new FormControl<string>(''),
@@ -25,7 +25,7 @@ export class BaseMetadataEditorComponent implements OnInit, OnDestroy {
     note: new FormControl<string>(''),
   };
 
-  form! : FormGroup;
+  form!: FormGroup;
   entry!: any;
   currentUser!: User;
   relations!: any;
@@ -89,7 +89,7 @@ export class BaseMetadataEditorComponent implements OnInit, OnDestroy {
     if (+entry.confidence !== -1) {
       formControlList['confidence'].setValue(+entry.confidence * 100);
     }
-    formControlList['note'].setValue(entry.note?? '');
+    formControlList['note'].setValue(entry.note ?? '');
   }
 
   ngOnDestroy(): void {
@@ -106,9 +106,9 @@ export class BaseMetadataEditorComponent implements OnInit, OnDestroy {
         return throwError(() => new Error(error.error));
       }),
     ).subscribe(resp => {
-      this.entry = { ...this.entry, [fieldName]: value, lastUpdate: resp};
-      const msg = this.msgConfService.generateSuccessMessageConfig(`Update "${relation}" success `);
-      this.messageService.add(msg);
+      this.entry = { ...this.entry, [fieldName]: value, lastUpdate: resp };
+      // const msg = this.msgConfService.generateSuccessMessageConfig(`Update "${relation}" success `);
+      // this.messageService.add(msg);
     });
   }
 
@@ -118,7 +118,7 @@ export class BaseMetadataEditorComponent implements OnInit, OnDestroy {
     if (fieldType === this.relations.CONFIDENCE) {
       value /= 100;
     } else if (fieldType === this.relations.NOTE) {
-      value = value?? '';
+      value = value ?? '';
     }
 
     return value;

--- a/src/app/controllers/editors/form-core-editor/form-core-editor.component.html
+++ b/src/app/controllers/editors/form-core-editor/form-core-editor.component.html
@@ -28,7 +28,7 @@
         </ng-template>
         <ng-template pTemplate="content">
           <form [formGroup]="form.controls.label">
-            <div class="field col-12" *ngFor="let control of labelFormItems">
+            <div class="field col-12" *ngFor="let control of labelFormItems; let i = index; trackBy:trackByIndexFn">
               <label [for]="control.propertyID">{{control.propertyID}}</label>
               <span class="justify-content-between">
                 <input pInputText [formControlName]="control.propertyID" type="text" [name]="control.propertyID"

--- a/src/app/controllers/editors/form-core-editor/form-core-editor.component.ts
+++ b/src/app/controllers/editors/form-core-editor/form-core-editor.component.ts
@@ -132,7 +132,7 @@ export class FormCoreEditorComponent implements OnInit, OnDestroy {
       takeUntil(this.unsubscribe$),
       debounceTime(500),
       distinctUntilChanged(),
-    ).subscribe((resp: {[key: string]: any}) => {
+    ).subscribe((resp: { [key: string]: any }) => {
       for (const key in resp) {
         const currentPropertyId = this.labelFormItems.findIndex(e => e.propertyID === key);
         if (currentPropertyId !== -1 && this.labelFormItems[currentPropertyId].propertyValue !== resp[key]) {
@@ -184,7 +184,7 @@ export class FormCoreEditorComponent implements OnInit, OnDestroy {
    */
   private movePropertyToForm(propertyID: string, propertyValue: string) {
     const formControl = new FormControl<string>(propertyValue, Validators.required);
-    const property = <PropertyElement> { propertyID, propertyValue };
+    const property = <PropertyElement>{ propertyID, propertyValue };
     this.label.addControl(propertyID, formControl);
     this.labelFormItems.push(property);
     this.representationItems = this.representationItems.filter(i => i.label !== propertyID);
@@ -199,8 +199,8 @@ export class FormCoreEditorComponent implements OnInit, OnDestroy {
     this.labelFormItems.splice(index, 1);
     this.label.removeControl(propertyID);
     this.representationItems.push({
-        label: propertyID,
-        command: () => this.movePropertyToForm(propertyID, ''),
+      label: propertyID,
+      command: () => this.movePropertyToForm(propertyID, ''),
     });
   }
 
@@ -278,6 +278,16 @@ export class FormCoreEditorComponent implements OnInit, OnDestroy {
   }
 
   /**
+ * TrackBy function based on the index of the element in the array, added to avoid losing the focus
+ * @param index {number} index of the element in the ngFor
+ * @param item {any} element
+ * @returns {number}
+ */
+  trackByIndexFn(index: number, item: any) {
+    return index;
+  }
+
+  /**
    * @private
    * Metodo che gestisce l'observable di update
    * @param updateObs {Observable<string>} observable del timestamp di ultimo aggiornamento
@@ -287,14 +297,14 @@ export class FormCoreEditorComponent implements OnInit, OnDestroy {
     updateObs.pipe(
       take(1),
       catchError((error: HttpErrorResponse) => {
-        const msg = this.msgConfService.generateSuccessMessageConfig(`"${relation}" update failed`);
+        const msg = this.msgConfService.generateWarningMessageConfig(`"${relation}" update failed`);
         this.messageService.add(msg);
         return throwError(() => new Error(error.error));
       }),
     ).subscribe(resp => {
       this.formEntry = { ...this.formEntry, lastUpdate: resp };
-      const msg = this.msgConfService.generateSuccessMessageConfig(`"${relation}" update success`);
-      this.messageService.add(msg);
+      // const msg = this.msgConfService.generateSuccessMessageConfig(`"${relation}" update success`);
+      // this.messageService.add(msg);
 
       if (relation === 'writtenRep') {
         this.commonService.notifyOther({

--- a/src/app/controllers/editors/lex-entry-editor/lex-entry-editor.component.ts
+++ b/src/app/controllers/editors/lex-entry-editor/lex-entry-editor.component.ts
@@ -418,7 +418,7 @@ export class LexEntryEditorComponent implements OnInit, OnDestroy {
       }),
     ).subscribe(resp => {
       this.lexicalEntry = <LexicalEntryCore>{ ...this.lexicalEntry, lastUpdate: resp };
-      this.messageService.add(this.msgConfService.generateSuccessMessageConfig(`${this.lexicalEntry.label} update "${relation}" success `));
+      // this.messageService.add(this.msgConfService.generateSuccessMessageConfig(`${this.lexicalEntry.label} update "${relation}" success `));
       this.commonService.notifyOther({ option: 'lexicon_edit_update_tree', value: this.lexicalEntry.lexicalEntry });
     });
   }

--- a/src/app/controllers/editors/sense-core-editor/sense-core-editor.component.html
+++ b/src/app/controllers/editors/sense-core-editor/sense-core-editor.component.html
@@ -17,7 +17,7 @@
         </ng-template>
         <ng-template pTemplate="content">
           <form [formGroup]="form.controls.definition">
-            <div class="field col-12" *ngFor="let control of definitionFormItems">
+            <div class="field col-12" *ngFor="let control of definitionFormItems; let i=index; trackBy:trackByIndexFn">
               <label [for]="control.propertyID">{{control.propertyID}}</label>
               <div class="d-flex justify-content-between" style="align-items: center;">
                 <textarea pInputTextarea [formControlName]="control.propertyID" [name]="control.propertyID"

--- a/src/app/controllers/editors/sense-core-editor/sense-core-editor.component.ts
+++ b/src/app/controllers/editors/sense-core-editor/sense-core-editor.component.ts
@@ -148,7 +148,7 @@ export class SenseCoreEditorComponent implements OnInit, OnDestroy {
    * @param propertyValue {string} valore iniziale della proprietà
    */
   private movePropertyToForm(propertyID: string, propertyValue: string): void {
-    const fieldProperty : PropertyElement = { propertyID, propertyValue };
+    const fieldProperty: PropertyElement = { propertyID, propertyValue };
     const control = new FormControl<string>(propertyValue, Validators.required);
     this.definitionFormItems.push(fieldProperty);
     this.definition.addControl(propertyID, control);
@@ -211,7 +211,7 @@ export class SenseCoreEditorComponent implements OnInit, OnDestroy {
       else {
         definition?.setValue('');
       }
-     });
+    });
   }
 
   /**
@@ -238,6 +238,16 @@ export class SenseCoreEditorComponent implements OnInit, OnDestroy {
   }
 
   /**
+   * TrackBy function based on the index of the element in the array, added to avoid losing the focus
+   * @param index {number} index of the element in the ngFor
+   * @param item {any} element
+   * @returns {number}
+   */
+  trackByIndexFn(index: number, item: any) {
+    return index;
+  }
+
+  /**
    * @private
    * Metodo che gestisce l'observable di update
    * @param updateObs {Observable<string>} observable del timestamp di ultimo aggiornamento
@@ -252,7 +262,7 @@ export class SenseCoreEditorComponent implements OnInit, OnDestroy {
       }),
     ).subscribe(resp => {
       this.senseEntry = <SenseCore>{ ...this.senseEntry, lastUpdate: resp };
-      this.messageService.add(this.msgConfService.generateSuccessMessageConfig(`"${relation}" update success `));
+      // this.messageService.add(this.msgConfService.generateSuccessMessageConfig(`"${relation}" update success `));
 
       if (relation === 'definition') {
         this.commonService.notifyOther({
@@ -277,7 +287,7 @@ export class SenseCoreEditorComponent implements OnInit, OnDestroy {
       return;
     }
 
-    const updater = <LexicalSenseUpdater> {
+    const updater = <LexicalSenseUpdater>{
       relation: this.commonService.getSenseUpdateRelation(relation),
       value: newValue,
     };

--- a/src/app/pages/workspace/workspace.component.ts
+++ b/src/app/pages/workspace/workspace.component.ts
@@ -1041,7 +1041,7 @@ export class WorkspaceComponent implements OnInit, AfterViewInit, OnDestroy {
       id: lexiconEditTileId,
       container: this.workspaceContainer,
       content: element,
-      headerTitle: 'Lexicon management - ' + lexicalEntryTree?.data?.label,
+      headerTitle: 'Lexicon editor - ' + lexicalEntryTree?.data?.label,
       maximizedMargin: 5,
       dragit: { snap: true },
       syncMargins: true,


### PR DESCRIPTION
- Removed success message in lexicon editing
- Added trackByFn for not losing focus in text fields within an ngFor
- Fixed the use of a success message instead of warning

Closes #112 
Closes #124 