### PR TITLE
98 retrieve filtered annotations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maia-fe",
-  "version": "0.9.3-1",
+  "version": "0.9.3-2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "maia-fe",
-      "version": "0.9.3-1",
+      "version": "0.9.3-2",
       "dependencies": {
         "@angular/animations": "^14.2.9",
         "@angular/cdk": "^14.2.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maia-fe",
-  "version": "0.9.2",
+  "version": "0.9.3-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "maia-fe",
-      "version": "0.9.2",
+      "version": "0.9.3-0",
       "dependencies": {
         "@angular/animations": "^14.2.9",
         "@angular/cdk": "^14.2.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maia-fe",
-  "version": "0.9.3-0",
+  "version": "0.9.3-1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "maia-fe",
-      "version": "0.9.3-0",
+      "version": "0.9.3-1",
       "dependencies": {
         "@angular/animations": "^14.2.9",
         "@angular/cdk": "^14.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maia-fe",
-  "version": "0.9.2",
+  "version": "0.9.3-0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maia-fe",
-  "version": "0.9.3-0",
+  "version": "0.9.3-1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maia-fe",
-  "version": "0.9.3-1",
+  "version": "0.9.3-2",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/controllers/page-controllers/footer/footer.component.html
+++ b/src/app/controllers/page-controllers/footer/footer.component.html
@@ -3,5 +3,5 @@
   <a href="https://www.ilc.cnr.it/klab/" class="font-medium ms-2" target="_blank">
     <img src="assets/img/KLAB_logo.png" height="13px" />
   </a>
-  <span>v. 0.1</span>
+  <span>v. {{APP_VERSION}}</span>
 </div>

--- a/src/app/controllers/page-controllers/footer/footer.component.ts
+++ b/src/app/controllers/page-controllers/footer/footer.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+declare const require: (path: string) => any;
 
 /**Componente del footer */
 @Component({
@@ -7,4 +8,5 @@ import { Component } from '@angular/core';
   styleUrls: ['./footer.component.scss']
 })
 export class FooterComponent {
+  APP_VERSION = require('../../../../../package.json').version;
 }

--- a/src/app/controllers/page-controllers/header/header.component.ts
+++ b/src/app/controllers/page-controllers/header/header.component.ts
@@ -12,7 +12,7 @@ import { environment } from 'src/environments/environment';
   styleUrls: ['./header.component.scss']
 })
 export class HeaderComponent {
-  applicationSubTitle = environment.applicationSubTitle;
+  applicationSubTitle = ` - ${environment.applicationSubTitle}`;;
   loggedUserName = this.loggedUserService.currentUser?.name + ' ' + this.loggedUserService.currentUser?.surname;
 
   /**

--- a/src/app/pages/login/login.component.ts
+++ b/src/app/pages/login/login.component.ts
@@ -16,7 +16,7 @@ import { environment } from 'src/environments/environment';
   styleUrls: ['./login.component.scss']
 })
 export class LoginComponent {
-  subTitle = environment.applicationSubTitle;
+  subTitle = ` - ${environment.applicationSubTitle}`;
   /**Authentication data form */
   loginForm = new FormGroup({
     username: new FormControl<string>('', Validators.required),

--- a/src/app/pages/workspace/workspace-menu/workspace-menu.component.html
+++ b/src/app/pages/workspace/workspace-menu/workspace-menu.component.html
@@ -1,6 +1,6 @@
 <p-menubar [model]="itemsInput" (click)="menuClick($event)" id="workspace-menu">
     <ng-template pTemplate="start">
-        <h3 class="px-4">MAIA - {{workspaceName}}</h3>
+        <h3 class="px-4">MAIA{{projectName}}- {{workspaceName}}</h3>
     </ng-template>
     <ng-template pTemplate="end">
         <a class="layout-topbar-logo text-dark fs-1" routerLink="/workspaces">

--- a/src/app/pages/workspace/workspace-menu/workspace-menu.component.ts
+++ b/src/app/pages/workspace/workspace-menu/workspace-menu.component.ts
@@ -1,6 +1,7 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
-import { MenuItem } from 'primeng/api';
 import { faHouseDamage } from '@fortawesome/free-solid-svg-icons';
+import { MenuItem } from 'primeng/api';
+import { environment } from 'src/environments/environment';
 
 /**Componente del menu del workspace */
 @Component({
@@ -17,6 +18,8 @@ export class WorkspaceMenuComponent {
 
   /**Icona fortawesome per uscire dal workspace */
   faHouseDamage = faHouseDamage;
+
+  projectName = ` - ${environment.applicationSubTitle} `;
 
   /**
    * Metodo che emette l'evento di click su una voce di menu

--- a/src/app/pages/workspace/workspace-text-window/workspace-text-window.component.ts
+++ b/src/app/pages/workspace/workspace-text-window/workspace-text-window.component.ts
@@ -1024,16 +1024,18 @@ export class WorkspaceTextWindowComponent implements OnInit, OnDestroy {
     const isSameLayers = this.commonService.compareArrays(visibleLayersIds,this.lastRenderedLayers);//I check if the same layers are visible as in the previous call
     const isSameRows = this.startRow === start && this.endRow === end;
 
-    if(isSameRows && isSameLayers) { //rows and annotations have not changed, I just need to recalculate the svg
-      this.renderData();
-      return;
+    let rowsReq: Observable<PaginatedResponse>;
+    let annotationsReq:Observable<TAnnotation[]>;
+    if(visibleLayersIds.length === 0) {
+      annotationsReq = of(<TAnnotation[]>[]);
+    } else {
+      if(isSameRows) {
+        annotationsReq = isSameLayers ? of(this.textoAnnotationsRes) : this.annotationService.retrieveResourceAnnotations(this.textId, { start: start, end: end, layers: visibleLayersIds });
+      } else {
+        annotationsReq = this.annotationService.retrieveResourceAnnotations(this.textId, { start: start, end: end, layers: visibleLayersIds });
+      }
     }
 
-    let requests = [];
-    let rowsReq: Observable<PaginatedResponse>;
-    const annotationsReq = visibleLayersIds.length > 0 ? 
-      this.annotationService.retrieveResourceAnnotations(this.textId, { start: start, end: end, layers: visibleLayersIds }) 
-      : of(<TAnnotation[]>[]);
     if(!isSameRows) {
       rowsReq = this.annotationService.retrieveTextSplitted(this.textId, { start: start, end: end });
     } else {

--- a/src/app/pages/workspace/workspace-text-window/workspace-text-window.component.ts
+++ b/src/app/pages/workspace/workspace-text-window/workspace-text-window.component.ts
@@ -107,8 +107,8 @@ export class WorkspaceTextWindowComponent implements OnInit, OnDestroy {
   selectedLayer: TLayer | undefined;
   /**Lista di layer selezionati */
   selectedLayers: TLayer[] | undefined = [];
-  startRow: number | null = null;
-  endRow: number | null = null;
+  previousStartRow: number | null = null;
+  previousEndRow: number | null = null;
   lastRenderedLayers: number[] = [];
 
   sentnumVerticalLine = "M 0 0";
@@ -1022,7 +1022,7 @@ export class WorkspaceTextWindowComponent implements OnInit, OnDestroy {
 
     const visibleLayersIds = this.selectedLayers?.map(l => l.id!) || [];
     const isSameLayers = this.commonService.compareArrays(visibleLayersIds, this.lastRenderedLayers);//I check if the same layers are visible as in the previous call
-    const isSameRows = this.startRow === start && this.endRow === end;
+    const isSameRows = this.previousStartRow === start && this.previousEndRow === end;
 
     let rowsReq: Observable<PaginatedResponse>;
     let annotationsReq: Observable<TAnnotation[]>;
@@ -1060,8 +1060,8 @@ export class WorkspaceTextWindowComponent implements OnInit, OnDestroy {
         return throwError(() => new Error(error.error));
       }),
     ).subscribe(([textResponse, tAnnotationsResponse]) => {
-      this.startRow = start;
-      this.endRow = end;
+      this.previousStartRow = start;
+      this.previousEndRow = end;
       this.lastRenderedLayers = visibleLayersIds;
       // this.layersList = layersResponse;
       this.textTotalRows = textResponse.count!;

--- a/src/app/pages/workspace/workspace-text-window/workspace-text-window.component.ts
+++ b/src/app/pages/workspace/workspace-text-window/workspace-text-window.component.ts
@@ -1,7 +1,8 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { ChangeDetectorRef, Component, ElementRef, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { MessageService, TreeNode } from 'primeng/api';
-import { Observable, Subject, catchError, forkJoin, of, switchMap, take, takeUntil, tap, throwError } from 'rxjs';
+import { Tree } from 'primeng/tree';
+import { Observable, Subject, catchError, forkJoin, of, switchMap, take, takeUntil, throttleTime, throwError } from 'rxjs';
 import { Annotation } from 'src/app/models/annotation/annotation';
 import { AnnotationMetadata } from 'src/app/models/annotation/annotation-metadata';
 import { SpanCoordinates } from 'src/app/models/annotation/span-coordinates';
@@ -12,23 +13,21 @@ import { Relations } from 'src/app/models/relation/relations';
 import { LineBuilder } from 'src/app/models/text/line-builder';
 import { TextHighlight } from 'src/app/models/text/text-highlight';
 import { TextLine } from 'src/app/models/text/text-line';
+import { TextRange } from 'src/app/models/text/text-range';
 import { TextRow } from 'src/app/models/text/text-row';
 import { ResourceElement } from 'src/app/models/texto/corpus-element';
+import { PaginatedResponse, TextSplittedRow } from 'src/app/models/texto/paginated-response';
+import { Section } from 'src/app/models/texto/section';
 import { TAnnotation } from 'src/app/models/texto/t-annotation';
 import { TAnnotationFeature } from 'src/app/models/texto/t-annotation-feature';
 import { TFeature } from 'src/app/models/texto/t-feature';
 import { TLayer } from 'src/app/models/texto/t-layer';
 import { AnnotationService } from 'src/app/services/annotation.service';
+import { CommonService } from 'src/app/services/common.service';
 import { LayerStateService } from 'src/app/services/layer-state.service';
 import { LoaderService } from 'src/app/services/loader.service';
 import { MessageConfigurationService } from 'src/app/services/message-configuration.service';
 import { WorkspaceService } from 'src/app/services/workspace.service';
-import { TextRange } from 'src/app/models/text/text-range';
-import { TextSplittedRow } from 'src/app/models/texto/paginated-response';
-import { Section } from 'src/app/models/texto/section';
-import { throttleTime } from 'rxjs';
-import { Tree } from 'primeng/tree';
-import { CommonService } from 'src/app/services/common.service';
 
 enum ScrollingDirectionType { Up, Down, InRange }
 
@@ -107,7 +106,10 @@ export class WorkspaceTextWindowComponent implements OnInit, OnDestroy {
   /**Layer selezionato */
   selectedLayer: TLayer | undefined;
   /**Lista di layer selezionati */
-  selectedLayers: TLayer[] | undefined;
+  selectedLayers: TLayer[] | undefined = [];
+  startRow: number|null = null;
+  endRow: number|null = null;
+  lastRenderedLayers: number[] = [];
 
   sentnumVerticalLine = "M 0 0";
   /**Definisce se visualizzare l'editor di annotazione */
@@ -1018,10 +1020,36 @@ export class WorkspaceTextWindowComponent implements OnInit, OnDestroy {
 
     this.relation = new Relation();
 
+    const visibleLayersIds = this.selectedLayers?.map(l => l.id!) || [];
+    const isSameLayers = this.commonService.compareArrays(visibleLayersIds,this.lastRenderedLayers);//I check if the same layers are visible as in the previous call
+    const isSameRows = this.startRow === start && this.endRow === end;
+
+    if(isSameRows && isSameLayers) { //rows and annotations have not changed, I just need to recalculate the svg
+      this.renderData();
+      return;
+    }
+
+    let requests = [];
+    let rowsReq: Observable<PaginatedResponse>;
+    const annotationsReq = visibleLayersIds.length > 0 ? 
+      this.annotationService.retrieveResourceAnnotations(this.textId, { start: start, end: end, layers: visibleLayersIds }) 
+      : of(<TAnnotation[]>[]);
+    if(!isSameRows) {
+      rowsReq = this.annotationService.retrieveTextSplitted(this.textId, { start: start, end: end });
+    } else {
+      const paginatedResponse = <PaginatedResponse>{
+        data: this.textSplittedRows,
+        count: this.textTotalRows,
+        start: start,
+        end: end,
+        offset: this.offset
+      };
+      rowsReq = of(paginatedResponse);
+    }
 
     forkJoin([
-      this.annotationService.retrieveTextSplitted(this.textId, { start: start, end: end }),
-      this.annotationService.retrieveResourceAnnotations(this.textId, { start: start, end: end }),
+      rowsReq,
+      annotationsReq
     ]).pipe(
       takeUntil(this.unsubscribe$),
       catchError((error: HttpErrorResponse) => {
@@ -1030,6 +1058,9 @@ export class WorkspaceTextWindowComponent implements OnInit, OnDestroy {
         return throwError(() => new Error(error.error));
       }),
     ).subscribe(([textResponse, tAnnotationsResponse]) => {
+      this.startRow = start;
+      this.endRow = end;
+      this.lastRenderedLayers = visibleLayersIds;
       // this.layersList = layersResponse;
       this.textTotalRows = textResponse.count!;
 

--- a/src/app/pages/workspace/workspace-text-window/workspace-text-window.component.ts
+++ b/src/app/pages/workspace/workspace-text-window/workspace-text-window.component.ts
@@ -107,8 +107,8 @@ export class WorkspaceTextWindowComponent implements OnInit, OnDestroy {
   selectedLayer: TLayer | undefined;
   /**Lista di layer selezionati */
   selectedLayers: TLayer[] | undefined = [];
-  startRow: number|null = null;
-  endRow: number|null = null;
+  startRow: number | null = null;
+  endRow: number | null = null;
   lastRenderedLayers: number[] = [];
 
   sentnumVerticalLine = "M 0 0";
@@ -261,10 +261,10 @@ export class WorkspaceTextWindowComponent implements OnInit, OnDestroy {
   /**initialize text range and load data */
   loadInitialData() {
     this.annotationService.retrieveTextTotalRows(this.textId!)
-    .pipe(
-      takeUntil(this.unsubscribe$),
-      catchError((error: HttpErrorResponse) => this.commonService.throwHttpErrorAndMessage(error, 'Error retrieving text total rows')),
-    )
+      .pipe(
+        takeUntil(this.unsubscribe$),
+        catchError((error: HttpErrorResponse) => this.commonService.throwHttpErrorAndMessage(error, 'Error retrieving text total rows')),
+      )
       .subscribe((result) => {
         this.textTotalRows = result!
 
@@ -1021,22 +1021,22 @@ export class WorkspaceTextWindowComponent implements OnInit, OnDestroy {
     this.relation = new Relation();
 
     const visibleLayersIds = this.selectedLayers?.map(l => l.id!) || [];
-    const isSameLayers = this.commonService.compareArrays(visibleLayersIds,this.lastRenderedLayers);//I check if the same layers are visible as in the previous call
+    const isSameLayers = this.commonService.compareArrays(visibleLayersIds, this.lastRenderedLayers);//I check if the same layers are visible as in the previous call
     const isSameRows = this.startRow === start && this.endRow === end;
 
     let rowsReq: Observable<PaginatedResponse>;
-    let annotationsReq:Observable<TAnnotation[]>;
-    if(visibleLayersIds.length === 0) {
+    let annotationsReq: Observable<TAnnotation[]>;
+    if (visibleLayersIds.length === 0) {
       annotationsReq = of(<TAnnotation[]>[]);
     } else {
-      if(isSameRows) {
+      if (isSameRows) {
         annotationsReq = isSameLayers ? of(this.textoAnnotationsRes) : this.annotationService.retrieveResourceAnnotations(this.textId, { start: start, end: end, layers: visibleLayersIds });
       } else {
         annotationsReq = this.annotationService.retrieveResourceAnnotations(this.textId, { start: start, end: end, layers: visibleLayersIds });
       }
     }
 
-    if(!isSameRows) {
+    if (!isSameRows) {
       rowsReq = this.annotationService.retrieveTextSplitted(this.textId, { start: start, end: end });
     } else {
       const paginatedResponse = <PaginatedResponse>{
@@ -1379,11 +1379,13 @@ export class WorkspaceTextWindowComponent implements OnInit, OnDestroy {
     let extraScrollPixels = 0;
 
     switch (this.scrollingDirection) {
-      case ScrollingDirectionType.Down:
+      case ScrollingDirectionType.Down: {
         scrolledBlockSize = this.rows.filter(r => r.rowIndex! <= this.precTextRange!.end - 1).reduce((acc, o) => acc + (o.height || 0), 0);
-        let scrollingRow = this.rows.filter(r => r.rowIndex === this.precTextRange!.end)[0];
+        const precTextRangeEnd = Math.trunc(this.precTextRange!.end); //remove decimals otherwise it doesn't find matching rowIndex
+        const scrollingRow = this.rows.filter(r => r.rowIndex === precTextRangeEnd)[0];
         extraScrollPixels = this.textContainer.nativeElement.clientHeight - scrollingRow.height!;
         break;
+      }
       case ScrollingDirectionType.Up:
         scrolledBlockSize = this.rows.filter(r => r.rowIndex! < this.precTextRange!.start).reduce((acc, o) => acc + (o.height || 0), 0);
         break;

--- a/src/app/services/annotation.service.ts
+++ b/src/app/services/annotation.service.ts
@@ -61,10 +61,10 @@ export class AnnotationService {
   /**
    * Retrieves the list of annotations associated with a portion of text.
    * @param resourceId {number} resource identifier
-   * @param slice {start: number, end: number|null} coordinates of the set of rows for which we want annotations
+   * @param slice {start: number, end: number|null} coordinates of the set of rows for which we want annotations and optional list of visible layer ids
    * @returns {Observable<TAnnotation[]>} observable of the annotation list
    */
-  public retrieveResourceAnnotations(resourceId: number, slice: { start: number, end: number }): Observable<TAnnotation[]> {
+  public retrieveResourceAnnotations(resourceId: number, slice: { start: number, end: number, layers?: number[] }): Observable<TAnnotation[]> {
     const uuid = uuidv4();
     return this.http.post<TAnnotation[]>(
       `${this.textoUrl}/util/resource/${resourceId}/annotations`,

--- a/src/app/services/common.service.ts
+++ b/src/app/services/common.service.ts
@@ -81,4 +81,9 @@ export class CommonService {
   public translateKey(key: string): string {
     return this.translateService.instant(key);
   }
+
+  public compareArrays(a: any[], b: any[]): boolean {
+    if(a.length!==b.length) return false;
+    return a.every(item => b.includes(item));
+  }
 }

--- a/src/environments/environment model.ts
+++ b/src/environments/environment model.ts
@@ -23,6 +23,6 @@ export const environment = {
   maiaBeTextoUrl: `${serverUrl}/texto`,
   lexoPrefix: "ferrandi",
   lexoBaseIRI: "http://rut/somali/ferrandi#",
-  applicationSubTitle: " - NAME",
+  applicationSubTitle: "NAME",
   demoHide: false,
 };

--- a/src/environments/environment.production.ts
+++ b/src/environments/environment.production.ts
@@ -16,6 +16,6 @@ export const environment = {
   maiaBeTextoUrl: `${serverUrl}/texto`,
   lexoPrefix: "lex",
   lexoBaseIRI: "http://lexica/mylexicon#",
-  applicationSubTitle: " VocaBO",
+  applicationSubTitle: "VocaBO",
   demoHide: true,
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -20,6 +20,6 @@ export const environment = {
   maiaBeTextoUrl: `${serverUrl}/texto`,
   lexoPrefix: "ferrandi",
   lexoBaseIRI: "http://rut/somali/ferrandi#",
-  applicationSubTitle: " - develop",
+  applicationSubTitle: "develop",
   demoHide: false,
 };


### PR DESCRIPTION
Closes https://github.com/klab-ilc-cnr/Maia/issues/98

Modifica del comportamento di visualizzazione dei layer di annotazione: in apertura di un testo sono sempre nascosti e non recuperati.
Ottimizzato il recupero delle righe e delle annotazioni in modo tale da eseguire le chiamate solo su richiesta di nuovi dati